### PR TITLE
Revert "add !theme with new url"

### DIFF
--- a/documentation/IDTA-01004/modules/ROOT/partials/diagrams/aas-registry-implementation.puml
+++ b/documentation/IDTA-01004/modules/ROOT/partials/diagrams/aas-registry-implementation.puml
@@ -1,5 +1,5 @@
 @startuml
-!theme idta from https://raw.githubusercontent.com/admin-shell-io/aas-specifications/main/plantuml/
+
  
 'LAYOUT_TOP_DOWN()
 'LAYOUT_AS_SKETCH()

--- a/documentation/IDTA-01004/modules/ROOT/partials/diagrams/aas-server-implementation.puml
+++ b/documentation/IDTA-01004/modules/ROOT/partials/diagrams/aas-server-implementation.puml
@@ -1,5 +1,5 @@
 @startuml
-!theme idta from https://raw.githubusercontent.com/admin-shell-io/aas-specifications/main/plantuml/
+
  
 'LAYOUT_TOP_DOWN()
 'LAYOUT_AS_SKETCH()

--- a/documentation/IDTA-01004/modules/ROOT/partials/diagrams/access-aas-servers.puml
+++ b/documentation/IDTA-01004/modules/ROOT/partials/diagrams/access-aas-servers.puml
@@ -1,5 +1,4 @@
 @startuml
-!theme idta from https://raw.githubusercontent.com/admin-shell-io/aas-specifications/main/plantuml/
 
 'LAYOUT_TOP_DOWN
 'LAYOUT_AS_SKETCH()


### PR DESCRIPTION
Reverts admin-shell-io/aas-specs-security#21, as the theme links are not needed.

The theme will be applied automatically by the Antora itself using the the following [puml with theme definiton](https://github.com/admin-shell-io/aas-specifications/blob/main/plantuml/include-theme-idta.puml). This puml will be applied as a prefix of each PUML file innside Antora.

It didn't work before, because the repository `aas-specs-antora` was renamed to `aas-specifications`, so the link in the [puml with theme definiton](https://github.com/admin-shell-io/aas-specifications/blob/main/plantuml/include-theme-idta.puml) was not valid anymore. I have updated it now.