### PR TITLE
fix(schema): align schema root with wrapped example format

### DIFF
--- a/documentation/IDTA-01004/modules/ROOT/partials/json/aas-queries-and-access-rules-schema.json
+++ b/documentation/IDTA-01004/modules/ROOT/partials/json/aas-queries-and-access-rules-schema.json
@@ -2,8 +2,20 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Common JSON Schema for AAS Queries and Access Rules",
   "description": "This schema contains the AAS Access Rule Language.",
-  "$ref": "#/definitions/AllAccessPermissionRules",
+  "$ref": "#/definitions/AccessRulesDocument",
   "definitions": {
+    "AccessRulesDocument": {
+      "type": "object",
+      "properties": {
+        "AllAccessPermissionRules": {
+          "$ref": "#/definitions/AllAccessPermissionRules"
+        }
+      },
+      "required": [
+        "AllAccessPermissionRules"
+      ],
+      "additionalProperties": false
+    },
     "standardString": {
       "type": "string",
       "pattern": "^[A-Za-z0-9/\\*\\[\\]\\(\\) _@#\\\\+\\-\\.,:\\$\\^]+$"


### PR DESCRIPTION
## Summary

Aligns the root of `aas-queries-and-access-rules-schema.json` with
the wrapper format used consistently by every example under
`partials/examples/*.json`.

## Problem

All shipped examples wrap their content in a top-level
`"AllAccessPermissionRules"` key:

```json
{
  "AllAccessPermissionRules": {
    "rules": [ ... ]
  }
}
```

But the schema root was:

```json
"$ref": "#/definitions/AllAccessPermissionRules"
```

which matches the inner object (the one whose `rules` is required),
not the outer wrapper. Consequently, none of the shipped examples
validate against the shipped schema out of the box.

## Solution

Introduce a thin wrapper definition `AccessRulesDocument` with a
single required property `AllAccessPermissionRules`, and retarget the
root `$ref`:

```json
"$ref": "#/definitions/AccessRulesDocument",
"definitions": {
  "AccessRulesDocument": {
    "type": "object",
    "required": ["AllAccessPermissionRules"],
    "properties": {
      "AllAccessPermissionRules": {
        "$ref": "#/definitions/AllAccessPermissionRules"
      }
    },
    "additionalProperties": false
  },
  ...
}
```

The internal shape of `AllAccessPermissionRules` is untouched.

## Impact

- Affected spec: IDTA-01004 (aas-specs-security)
- No behavioural change for rule content; only the top-level shape
  expected by validators changes.
- All existing examples now validate. Consumers that previously
  hand-stripped the wrapper must either wrap their payload or
  continue to validate against
  `#/definitions/AllAccessPermissionRules` directly.

## Review notes

- Please confirm the wrapper key and that no downstream tooling
  already validates the **inner** shape; if so, that is still
  reachable via `$ref: "#/definitions/AllAccessPermissionRules"`.
- The API spec (`aas-specs-api`) is intentionally not touched — the
  Query examples there are already unwrapped (`{"$condition": …}`),
  consistent with their schema root.

## Related

Review Finding **T-03**: Schema/example wrapper mismatch.
