### PR TITLE
fix(examples): correct broken BNF and JSON example files

### DIFF
--- a/documentation/IDTA-01004/modules/ROOT/partials/examples/allow-create-only-specific.json
+++ b/documentation/IDTA-01004/modules/ROOT/partials/examples/allow-create-only-specific.json
@@ -23,7 +23,9 @@
             {
               "$eq": [
                 {
-                  "CLAIM": "Role"
+                  "$attribute": {
+                    "CLAIM": "Role"
+                  }
                 },
                 {
                   "$strVal": "person with legitimate interest"

--- a/documentation/IDTA-01004/modules/ROOT/partials/examples/allow-read-all-users-of-company-for-submodel.bnf
+++ b/documentation/IDTA-01004/modules/ROOT/partials/examples/allow-read-all-users-of-company-for-submodel.bnf
@@ -1,6 +1,6 @@
 ACCESSRULE:
   ATTRIBUTES:
-  CLAIM("email")
+    CLAIM("email")
   RIGHTS: READ
   ACCESS: ALLOW
   OBJECTS:

--- a/documentation/IDTA-01004/modules/ROOT/partials/examples/allow-read-list-semanticids-machinestate.json
+++ b/documentation/IDTA-01004/modules/ROOT/partials/examples/allow-read-list-semanticids-machinestate.json
@@ -19,9 +19,16 @@
           }
         ],
         "FORMULA": {
-          "REFERENCE": {
-            "$sme(\"SubmodelID-OperationalData\").machineState#value"
-          }
+          "$eq": [
+            {
+              "$attribute": {
+                "REFERENCE": "$sme(\"SubmodelID-OperationalData\").machineState#value"
+              }
+            },
+            {
+              "$strVal": "not-running"
+            }
+          ]
         }
       }
     ]

--- a/documentation/IDTA-01004/modules/ROOT/partials/examples/allow-read-submodels-id-pattern.bnf
+++ b/documentation/IDTA-01004/modules/ROOT/partials/examples/allow-read-submodels-id-pattern.bnf
@@ -1,6 +1,6 @@
 ACCESSRULE:
   ATTRIBUTES:
-  CLAIM("companyName")
+    CLAIM("companyName")
   RIGHTS: READ
   ACCESS: ALLOW
   OBJECTS:

--- a/documentation/IDTA-01004/modules/ROOT/partials/examples/filter.bnf
+++ b/documentation/IDTA-01004/modules/ROOT/partials/examples/filter.bnf
@@ -4,7 +4,7 @@ ACCESSRULE:
   RIGHTS: READ
   ACCESS: ALLOW
   OBJECTS:
-    DESCRIPTOR $aasDesc("*")
+    DESCRIPTOR $aasdesc("*")
   FORMULA:
     $and(
       CLAIM("BusinessPartnerNumber") $eq "BPNL00000000000A",
@@ -19,7 +19,7 @@ ACCESSRULE:
       )
     )
   FILTER:
-    FRAGMENT "$aasdesc#specificAssetIds[]"
+    FRAGMENT: $aasdesc#specificAssetIds[]
     CONDITION:
     $or(
       $match(

--- a/documentation/IDTA-01004/modules/ROOT/partials/examples/filter.json
+++ b/documentation/IDTA-01004/modules/ROOT/partials/examples/filter.json
@@ -15,7 +15,7 @@
         },
         "OBJECTS": [
           {
-            "DESCRIPTOR": "$aasDesc(\"*\")"
+            "DESCRIPTOR": "$aasdesc(\"*\")"
           }
         ],
         "FORMULA": {

--- a/documentation/IDTA-01004/modules/ROOT/partials/examples/reuse-acl-object-formula.json
+++ b/documentation/IDTA-01004/modules/ROOT/partials/examples/reuse-acl-object-formula.json
@@ -22,7 +22,7 @@
         "name": "Properties",
         "objects": [
           {
-            "REFERABLE": "$sme("\https://s1.com\").p1"
+            "REFERABLE": "$sme(\"https://s1.com\").p1"
           },
           {
             "REFERABLE": "$sme(\"https://s1.com\").p2"


### PR DESCRIPTION
## Summary

Fixes concrete bugs in the BNF and JSON example files under
`documentation/IDTA-01004/modules/ROOT/partials/examples/`. Wider
CI-side example validation is intentionally deferred to the
conformance-tests PR (T-16).

## Problem

Several examples were broken in ways that prevent them from being
used as normative illustrations:

- `filter.bnf`, `filter.json`: `DESCRIPTOR $aasDesc("*")` — the
  grammar token is `$aasdesc`. Case-sensitive parsers reject this.
- `filter.bnf`: `FILTER: FRAGMENT "$aasdesc#specificAssetIds[]"`
  used the old route-literal form. The current
  `<SecurityQueryFilter>` requires
  `FRAGMENT: <FieldIdentifierFragment>`.
- `allow-read-list-semanticids-machinestate.json`: `FORMULA` was
  not a `logicalExpression` at all; it contained a stray
  `"REFERENCE"` object with a dangling string, not even well-formed
  JSON of a formula value.
- `reuse-acl-object-formula.json`: the first `REFERABLE` had an
  unbalanced escape sequence `"$sme("\https://s1.com\").p1"`.
- `allow-create-only-specific.json`: `$eq` compared
  `{"CLAIM": "Role"}` directly (an attribute descriptor) instead of
  wrapping it in `{"$attribute": {"CLAIM": "Role"}}`.
- `allow-read-all-users-of-company-for-submodel.bnf`,
  `allow-read-submodels-id-pattern.bnf`: `CLAIM("…")` was at the
  same indentation as `RIGHTS`, so the attribute was visually not
  scoped under `ATTRIBUTES:`.

## Solution

Targeted fixes only, keeping the examples' original intent:

- Lowercase `$aasdesc` throughout `filter.*`.
- Rewrite the FILTER fragment clause to the field-identifier form.
- Rewrite `allow-read-list-semanticids-machinestate.json` `FORMULA`
  to mirror its `.bnf` twin: `$eq` of the REFERENCE `$attribute` and
  a `$strVal "not-running"`.
- Correct the escape sequence in `reuse-acl-object-formula.json`.
- Wrap `CLAIM` in `$attribute` in `allow-create-only-specific.json`.
- Re-indent `CLAIM("…")` under `ATTRIBUTES:` in the two BNF files.

All 11 JSON examples under `partials/examples/` now parse as valid
JSON.

## Impact

- Affected spec: IDTA-01004 (aas-specs-security)
- Consumers copying these snippets get working grammar and schema
  inputs.
- No structural changes to the schemas or grammar.

## Review notes

- Please sanity-check that the intent of
  `allow-read-list-semanticids-machinestate.json` (allow `EXECUTE`
  only when machineState is `"not-running"`) is what the original
  authors wanted — the previous content was unreconstructable; this
  interpretation follows the sibling `.bnf` file.
- The `filter.*` FRAGMENT rewrite depends on the canonical
  `SecurityQueryFilter` form from the Security BNF; it is orthogonal
  to the API-side harmonization in the parallel API PR.

## Related

Review Finding **T-12**: Broken example files.
Complements: T-02 (`aas-specs-api` PR #579) for the canonical
`SecurityQueryFilter` shape.
