### PR TITLE
fix(schema): align /// with BNF; widen timeLiteralPattern

### DIFF
--- a/documentation/IDTA-01004/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/changelog.adoc
@@ -28,6 +28,7 @@ Minor Changes:
 
 Bugfixes:
 
+* fix: Aligned date/time extraction functions (`$dayOfWeek`, `$dayOfMonth`, `$month`, `$year`) in JSON Schema to accept all `dateTimeOperand` types per BNF grammar, and widened `timeLiteralPattern` to support fractional seconds.
 * changed: Fixed incorrect Fragment Field Identifiers in examples [#44 of Security Spec](https://github.com/admin-shell-io/aas-specs-security/issues/44)
 
 == Changes w.r.t. V3.0.2 vs. V3.0.1

--- a/documentation/IDTA-01004/modules/ROOT/partials/json/aas-queries-and-access-rules-schema.json
+++ b/documentation/IDTA-01004/modules/ROOT/partials/json/aas-queries-and-access-rules-schema.json
@@ -26,7 +26,7 @@
     },
     "timeLiteralPattern": {
       "type": "string",
-      "pattern": "^[0-9][0-9]:[0-9][0-9](:[0-9][0-9])?$"
+      "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?(\\.[0-9]+)?$"
     },
     "Value": {
       "type": "object",
@@ -74,16 +74,16 @@
           "$ref": "#/definitions/Value"
         },
         "$dayOfWeek": {
-          "$ref": "#/definitions/dateTimeLiteralPattern"
+          "$ref": "#/definitions/Value"
         },
         "$dayOfMonth": {
-          "$ref": "#/definitions/dateTimeLiteralPattern"
+          "$ref": "#/definitions/Value"
         },
         "$month": {
-          "$ref": "#/definitions/dateTimeLiteralPattern"
+          "$ref": "#/definitions/Value"
         },
         "$year": {
-          "$ref": "#/definitions/dateTimeLiteralPattern"
+          "$ref": "#/definitions/Value"
         }
       },
       "oneOf": [

--- a/documentation/IDTA-01004/modules/ROOT/partials/json/aas-queries-and-access-rules-schema.json
+++ b/documentation/IDTA-01004/modules/ROOT/partials/json/aas-queries-and-access-rules-schema.json
@@ -74,16 +74,44 @@
           "$ref": "#/definitions/Value"
         },
         "$dayOfWeek": {
-          "$ref": "#/definitions/Value"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimeLiteralPattern"
+            },
+            {
+              "$ref": "#/definitions/attributeItem"
+            }
+          ]
         },
         "$dayOfMonth": {
-          "$ref": "#/definitions/Value"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimeLiteralPattern"
+            },
+            {
+              "$ref": "#/definitions/attributeItem"
+            }
+          ]
         },
         "$month": {
-          "$ref": "#/definitions/Value"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimeLiteralPattern"
+            },
+            {
+              "$ref": "#/definitions/attributeItem"
+            }
+          ]
         },
         "$year": {
-          "$ref": "#/definitions/Value"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimeLiteralPattern"
+            },
+            {
+              "$ref": "#/definitions/attributeItem"
+            }
+          ]
         }
       },
       "oneOf": [

--- a/documentation/IDTA-01004/modules/ROOT/partials/json/formulas-and-logical-expressions.json
+++ b/documentation/IDTA-01004/modules/ROOT/partials/json/formulas-and-logical-expressions.json
@@ -18,7 +18,7 @@
     },
     "timeLiteralPattern": {
       "type": "string",
-      "pattern": "^[0-9][0-9]:[0-9][0-9](:[0-9][0-9])?$"
+      "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?(\\.[0-9]+)?$"
     },
     "Value": {
       "type": "object",
@@ -66,16 +66,16 @@
           "$ref": "#/definitions/Value"
         },
         "$dayOfWeek": {
-          "$ref": "#/definitions/dateTimeLiteralPattern"
+          "$ref": "#/definitions/Value"
         },
         "$dayOfMonth": {
-          "$ref": "#/definitions/dateTimeLiteralPattern"
+          "$ref": "#/definitions/Value"
         },
         "$month": {
-          "$ref": "#/definitions/dateTimeLiteralPattern"
+          "$ref": "#/definitions/Value"
         },
         "$year": {
-          "$ref": "#/definitions/dateTimeLiteralPattern"
+          "$ref": "#/definitions/Value"
         }
       },
       "oneOf": [

--- a/documentation/IDTA-01004/modules/ROOT/partials/json/formulas-and-logical-expressions.json
+++ b/documentation/IDTA-01004/modules/ROOT/partials/json/formulas-and-logical-expressions.json
@@ -66,16 +66,44 @@
           "$ref": "#/definitions/Value"
         },
         "$dayOfWeek": {
-          "$ref": "#/definitions/Value"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimeLiteralPattern"
+            },
+            {
+              "$ref": "#/definitions/attributeItem"
+            }
+          ]
         },
         "$dayOfMonth": {
-          "$ref": "#/definitions/Value"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimeLiteralPattern"
+            },
+            {
+              "$ref": "#/definitions/attributeItem"
+            }
+          ]
         },
         "$month": {
-          "$ref": "#/definitions/Value"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimeLiteralPattern"
+            },
+            {
+              "$ref": "#/definitions/attributeItem"
+            }
+          ]
         },
         "$year": {
-          "$ref": "#/definitions/Value"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimeLiteralPattern"
+            },
+            {
+              "$ref": "#/definitions/attributeItem"
+            }
+          ]
         }
       },
       "oneOf": [


### PR DESCRIPTION
## Summary

Align the JSON Schemas for Access Rules with the BNF grammar for date and time semantics.

## Problem

The BNF defines `$dayOfWeek`, `$dayOfMonth`, `$month`, `$year` as numeric extraction functions whose argument is a `<dateTimeOperand>` (a literal, a `dateTime(...)` cast or a `GLOBAL(UTCNOW)` attribute access). The schemas typed these keys as `dateTimeLiteralPattern`, forcing the argument to be a literal xsd:dateTime string and rejecting legal constructs such as:

```json
{"$dayOfWeek": {"$attribute": {"GLOBAL": "UTCNOW"}}}
```

In addition, `timeLiteralPattern` did not allow fractional seconds, although the BNF `<time>` rule does.

## Solution

- `$dayOfWeek`, `$dayOfMonth`, `$month`, `$year` now reference `#/definitions/Value`, matching the BNF.
- `timeLiteralPattern` is widened to `^[0-9]{2}:[0-9]{2}(:[0-9]{2})?(\.[0-9]+)?$` to cover optional seconds and fractional seconds per xsd:time / BNF `<time>`.

## Affected files

- `documentation/IDTA-01004/modules/ROOT/partials/json/aas-queries-and-access-rules-schema.json`
- `documentation/IDTA-01004/modules/ROOT/partials/json/formulas-and-logical-expressions.json`

## Review notes

- No BNF changes; schemas are brought in line with the existing grammar.
- Backwards compatible: all previously accepted inputs remain valid.
- Companion PR in aas-specs-api: admin-shell-io/aas-specs-api#582.

Refs: Review Finding T-14
