### PR TITLE
docs(access-rules): clarify Descriptor FieldIdentifier applicability

### DIFF
--- a/documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc
@@ -273,6 +273,15 @@ For HTTP/REST APIs the examples in xref:annex/route-examples.adoc[] show how ROU
 
 An Object Group defines a list of single objects and/or a list of names of other object groups.
 
+[[descriptor-applicability]]
+===== Descriptor FieldIdentifier Applicability
+
+Descriptor-based FieldIdentifiers (`$aasdesc`, `$smdesc`) address metadata that is only available when the deployment implements a Registry profile according to IDTA-01002 (for example `AssetAdministrationShellRegistryServiceSpecification/SSP-001` or `SubmodelRegistryServiceSpecification/SSP-001`).
+
+In deployments that do not expose Registry endpoints (pure Repository profiles such as `AssetAdministrationShellRepositoryServiceSpecification/SSP-002`), access rules that reference `$aasdesc` or `$smdesc` are *not applicable*: the referenced metadata does not exist in the deployment, so the rule neither grants nor denies access. Evaluation MUST NOT fail because of such a rule; the rule is skipped for that request and any other applicable rules continue to apply.
+
+Implementations SHOULD therefore scope Descriptor-based rules to deployments in which at least one Registry profile is supported. The concrete applicability per IDTA-01002 profile is listed in IDTA-01002 § "Service Specifications and Profiles", sub-section xref:IDTA-01002:http-rest-api/service-specifications-and-profiles.adoc#fieldidentifier-applicability[FieldIdentifier applicability per profile].
+
 ==== Formulas
 
 [source,bnf,linenums]


### PR DESCRIPTION
## Summary

Clarify in the Access Rule Model that Descriptor-based FieldIdentifiers (`$aasdesc`, `$smdesc`) are only meaningful in Registry deployments, and specify how non-applicable rules MUST behave.

## Problem

`$aasdesc` and `$smdesc` access Registry metadata that is only exposed by the Registry profiles of IDTA-01002. In deployments that do not implement a Registry profile (e.g. a pure AAS Repository deployment), there is no descriptor data to evaluate against. The specification currently does not say what should happen for such a rule, so implementations disagree on whether to fail, deny or ignore it.

## Solution

Add a small "Descriptor FieldIdentifier Applicability" paragraph to the Objects section of the Access Rule Model. Rules that reference `$aasdesc` or `$smdesc` in non-Registry deployments are treated as *not applicable*: they neither grant nor deny and MUST NOT cause evaluation to fail. A cross-reference points to the new "FieldIdentifier Applicability per Profile" table in IDTA-01002.

## Affected files

- `documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc`

## Review notes

- Paired PR: `admin-shell-io/aas-specs-api#584` introduces the applicability table referenced from here.
- Editorial change only; no BNF or JSON Schema change.

Refs: Review Finding T-07
