### PR TITLE
docs(access-rules): reference IDTA-01002 Operation-to-RIGHT annex

### DIFF
--- a/documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc
@@ -159,6 +159,8 @@ The RIGHTS values are technology-neutral permissions. For HTTP/REST APIs these p
 The mapping in <<table-rights-to-verbs>> is intended to improve interoperability when ROUTE objects are used for authorization decisions.
 Concrete informative examples for RIGHTS, ROUTEs and HTTP requests are given in xref:annex/route-examples.adoc[].
 
+The normative operation-level mapping for the AAS HTTP/REST API (per-operation RIGHT and ROUTE) is defined in IDTA-01002 § "Operation to RIGHT Mapping" (annex). Implementations of this specification MUST follow that mapping when evaluating access rules against concrete HTTP operations.
+
 [[table-rights-to-verbs]]
 .Indicative mapping of RIGHTS to AAS operation verbs and HTTP methods
 [cols="1,2,2,4",options="header"]


### PR DESCRIPTION
## Summary

Point the Access Rule Model at the new normative "Operation to RIGHT Mapping" annex that is introduced in IDTA-01002.

## Problem

The indicative Rights-to-verbs table in `access-rule-model.adoc` is not sufficient to derive the required RIGHT for a concrete API operation (e.g. `PUT /submodels/{id}` => CREATE or UPDATE; `POST .../invoke` => EXECUTE; `GET /shell-descriptors` => VIEW). Implementations disagreed on these per-operation bindings.

## Solution

Add a short paragraph after the indicative table that directs implementers to the normative per-operation mapping in IDTA-01002. The indicative mapping stays in place for orientation.

## Affected files

- `documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc`

## Review notes

- Paired API PR: `admin-shell-io/aas-specs-api#586` introduces the new annex.
- Editorial only; no BNF / JSON Schema changes.

Refs: Review Finding T-10
