### PR TITLE
docs(access-rule-model): reference cross-spec terminology matrix (T-09)

### DIFF
--- a/documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc
@@ -46,6 +46,11 @@ The symbol FieldIdentifier allows to use attributes of
 AAS, Submodel, SubmodelElement, ConceptDescription, AAS-Descriptor and Submodel-Descriptor. 
 Depending on the type of repository or registry such attributes are allowed or not.
 
+[NOTE]
+====
+The FieldIdentifier prefixes `$aas`, `$sm`, `$sme`, `$cd`, `$aasdesc` and `$smdesc` correspond directly to the Metamodel classes `AssetAdministrationShell`, `Submodel`, `SubmodelElement`, `ConceptDescription`, `AssetAdministrationShellDescriptor` and `SubmodelDescriptor`, and to the API resources `/shells`, `/submodels`, `.../submodel-elements/{idShortPath}`, `/concept-descriptions`, `/shell-descriptors` and `/submodel-descriptors` respectively. The normative cross-specification mapping is given in the "Terminology Across IDTA-01001, IDTA-01002 and IDTA-01004" section of IDTA-01001 (AAS Metamodel). All prefixes are lower-case; variants such as `$aasDesc` or `$SmDesc` MUST be rejected by conforming parsers.
+====
+
 
 The AAS Query Language and the AAS Access Rules share the same BNF grammar for formula expressions.
 In addition to the text below, the further details of the formula expressions are explained in  link:https://industrialdigitaltwin.io/aas-specifications/IDTA-01002/v3.1/query-language.html[IDTA-01002, Query Language] .


### PR DESCRIPTION
## Summary

Add a NOTE in the grammar introduction of the Access Rule Model chapter that explicitly maps each FieldIdentifier prefix (`$aas`, `$sm`, `$sme`, `$cd`, `$aasdesc`, `$smdesc`) to the corresponding Metamodel class and API resource path, and points to the new normative cross-spec terminology matrix in IDTA-01001.

## Problem

The Access Rule Model chapter names the possible FieldIdentifier prefixes but does not make the link to Metamodel classes and API resources explicit. Across the three specs different surface forms are used for the same concept (`AssetAdministrationShell` vs. `/shells` vs. `$aas`), which regularly produces small inconsistencies (e.g. `$aasDesc` vs. `$aasdesc`).

## Solution

- Add a short normative NOTE right after the first mention of FieldIdentifier in the grammar introduction.
- Explicitly state that prefixes are lower-case and that variants like `$aasDesc` MUST be rejected by conforming parsers.
- Reference the new "Terminology Across IDTA-01001, IDTA-01002 and IDTA-01004" section in IDTA-01001 (Metamodel) as the normative single source of truth.

## Affected files

- `documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc`

## Review notes

- No grammar/schema changes.
- Companion PRs: `admin-shell-io/aas-specs-metamodel` (introduces the matrix) and `admin-shell-io/aas-specs-api` (mirrors this NOTE in the Query Language chapter).

Refs: Review Finding T-09
