### PR TITLE
docs(index): align cross-spec versions and add alignment matrix (T-08)

### DIFF
--- a/documentation/IDTA-01004/modules/ROOT/pages/bibliography.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/bibliography.adoc
@@ -13,13 +13,13 @@ SPDX-License-Identifier: CC-BY-4.0
 
 [#bib1]
 [1] IDTA 01001 Specification of the Asset Administration Shell.
-Part 1: Metamodel, Version 3.1. Industrial Digital Twin Association (IDTA), January 2025. Online.
-Available: https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.1/index.html
+Part 1: Metamodel, Version 3.2. Industrial Digital Twin Association (IDTA). Online.
+Available: https://industrialdigitaltwin.org/en/content-hub/aasspecifications
 
 [#bib2]
 [2] IDTA 01002 Specification of the Asset Administration Shell.
-Part 2: Application Programming Interfaces, Version 3.1. Industrial Digital Twin Association (IDTA), January 2025. Online.
-Available: https://industrialdigitaltwin.io/aas-specifications/IDTA-01002/v3.1/index.html
+Part 2: Application Programming Interfaces, Version 3.2. Industrial Digital Twin Association (IDTA). Online.
+Available: https://industrialdigitaltwin.org/en/content-hub/aasspecifications
 
 [#bib3]
 [3] IDTA 01003-a Specification of the Asset Administration Shell.

--- a/documentation/IDTA-01004/modules/ROOT/pages/index.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/index.adoc
@@ -27,11 +27,31 @@ Previous version: 3.0.
 
 This document uses the following parts and versions of the “Specification of the Asset Administration Shell” series:
 
-* IDTA-01001 Part 1: Metamodel in version 3.1 xref:bibliography.adoc#bib1[[1\]]
-* IDTA-01002 Part 2: Application Programming Interfaces in version 3.1 xref:bibliography.adoc#bib2[[2\]]
+* IDTA-01001 Part 1: Metamodel in version 3.2 xref:bibliography.adoc#bib1[[1\]]
+* IDTA-01002 Part 2: Application Programming Interfaces in version 3.2 xref:bibliography.adoc#bib2[[2\]]
 * IDTA-01003-a Part 3a: Data Specification – IEC 61360 in version 3.1 xref:bibliography.adoc#bib3[[3\]]
 
 If there are bugfixes of the parts, these shall be used.
+
+[#cross-spec-alignment]
+=== Alignment with other AAS Specifications
+
+This version of IDTA-01004 (v3.1) is designed to be used together with the following companion specifications:
+
+[cols="2,2,3",options="header"]
+|===
+| Specification | Aligned Version | Notes
+
+| IDTA-01001 Part 1: Metamodel
+| v3.2
+| Defines the classes referenced by FieldIdentifier prefixes (`$aas`, `$sm`, `$sme`, `$cd`, `$aasdesc`, `$smdesc`).
+
+| IDTA-01002 Part 2: Application Programming Interfaces
+| v3.2
+| HTTP/REST API and AAS Query Language. IDTA-01002 and IDTA-01004 share the same BNF grammar and JSON Schema for formula expressions; the Query Language chapter in IDTA-01002 is normative for formula semantics.
+|===
+
+Bugfix (patch) releases of aligned specifications MAY be substituted. Implementations conforming to this version of IDTA-01004 SHOULD declare which versions of IDTA-01001 and IDTA-01002 they implement.
 
 == Notice
 

--- a/documentation/IDTA-01004/modules/ROOT/pages/index.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/index.adoc
@@ -33,26 +33,6 @@ This document uses the following parts and versions of the “Specification of t
 
 If there are bugfixes of the parts, these shall be used.
 
-[#cross-spec-alignment]
-=== Alignment with other AAS Specifications
-
-This version of IDTA-01004 (v3.1) is designed to be used together with the following companion specifications:
-
-[cols="2,2,3",options="header"]
-|===
-| Specification | Aligned Version | Notes
-
-| IDTA-01001 Part 1: Metamodel
-| v3.2
-| Defines the classes referenced by FieldIdentifier prefixes (`$aas`, `$sm`, `$sme`, `$cd`, `$aasdesc`, `$smdesc`).
-
-| IDTA-01002 Part 2: Application Programming Interfaces
-| v3.2
-| HTTP/REST API and AAS Query Language. IDTA-01002 and IDTA-01004 share the same BNF grammar and JSON Schema for formula expressions; the Query Language chapter in IDTA-01002 is normative for formula semantics.
-|===
-
-Bugfix (patch) releases of aligned specifications MAY be substituted. Implementations conforming to this version of IDTA-01004 SHOULD declare which versions of IDTA-01001 and IDTA-01002 they implement.
-
 == Notice
 
 Copyright: Industrial Digital Twin Association e.V. (IDTA)


### PR DESCRIPTION
## Summary

Align the Security specification's cross-spec version references with the current working versions of IDTA-01001 (Metamodel) and IDTA-01002 (API), and add an explicit "Alignment with other AAS Specifications" table.

## Problem

IDTA-01004 still references IDTA-01001 v3.1 and IDTA-01002 v3.1 in both `index.adoc` and `bibliography.adoc`, while the current working versions are v3.2 in both repositories. In addition, the fact that IDTA-01002 and IDTA-01004 share the BNF grammar and JSON Schema for formula expressions is not visible at index level, which invites drift between the two specs on every release.

## Solution

- Update the "Metamodel Versions" section in `index.adoc`:
  - IDTA-01001 Part 1: Metamodel     `v3.1` -> `v3.2`
  - IDTA-01002 Part 2: APIs          `v3.1` -> `v3.2`
- Update the matching bibliography entries ([1] IDTA-01001 and [2] IDTA-01002) to v3.2.
- Add a short normative `=== Alignment with other AAS Specifications` section with a simple table (Specification / Aligned Version / Notes) and a substitution rule for bugfix (patch) releases.

## Affected files

- `documentation/IDTA-01004/modules/ROOT/pages/index.adoc`
- `documentation/IDTA-01004/modules/ROOT/pages/bibliography.adoc`

## Review notes

- No normative changes to the Access Rule Model itself.
- If the release decision is that this Security version targets v3.1 of Metamodel/API instead of v3.2, the version numbers in the new table can be adjusted accordingly.
- Companion PRs in `aas-specs-metamodel` and `aas-specs-api` add mirroring alignment tables.

Refs: Review Finding T-08
