### PR TITLE
docs(access-rule-model): declare IDTA-01002 as SoT for formula grammar (T-01)

### DIFF
--- a/documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc
@@ -50,6 +50,15 @@ Depending on the type of repository or registry such attributes are allowed or n
 The AAS Query Language and the AAS Access Rules share the same BNF grammar for formula expressions.
 In addition to the text below, the further details of the formula expressions are explained in  link:https://industrialdigitaltwin.io/aas-specifications/IDTA-01002/v3.1/query-language.html[IDTA-01002, Query Language] .
 
+[IMPORTANT]
+====
+*Single source of truth.* The BNF grammar and JSON Schema productions for *formula expressions* (logical expressions, comparisons, FieldIdentifiers, value literals, operands, type casts, and `$match` / `$and` / `$or` / `$not` operators) are *normatively defined in IDTA-01002 Part 2* (Query Language chapter and its JSON Schema).
+
+This specification (IDTA-01004) reuses these shared productions without modification. Access-Rule-specific productions (`ACL`, `OBJECTS`, `RIGHTS`, `ACCESS`, `ROUTE`, `FILTER`, `DEFATTRIBUTES`, `DEFACLS`, `DEFOBJECTS`, `DEFFORMULAS`, etc.) are defined on top of the shared formula grammar in the sections below.
+
+In case of an editorial conflict between the two specifications for a shared production, IDTA-01002 is authoritative. Bugfixes to shared productions in IDTA-01002 are automatically inherited by IDTA-01004.
+====
+
 .Access Rule Model
 [[image-access-rule-model]]
 [plantuml,mage-access-rule-model,svg]

--- a/documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc
@@ -50,15 +50,6 @@ Depending on the type of repository or registry such attributes are allowed or n
 The AAS Query Language and the AAS Access Rules share the same BNF grammar for formula expressions.
 In addition to the text below, the further details of the formula expressions are explained in  link:https://industrialdigitaltwin.io/aas-specifications/IDTA-01002/v3.1/query-language.html[IDTA-01002, Query Language] .
 
-[IMPORTANT]
-====
-*Single source of truth.* The BNF grammar and JSON Schema productions for *formula expressions* (logical expressions, comparisons, FieldIdentifiers, value literals, operands, type casts, and `$match` / `$and` / `$or` / `$not` operators) are *normatively defined in IDTA-01002 Part 2* (Query Language chapter and its JSON Schema).
-
-This specification (IDTA-01004) reuses these shared productions without modification. Access-Rule-specific productions (`ACL`, `OBJECTS`, `RIGHTS`, `ACCESS`, `ROUTE`, `FILTER`, `DEFATTRIBUTES`, `DEFACLS`, `DEFOBJECTS`, `DEFFORMULAS`, etc.) are defined on top of the shared formula grammar in the sections below.
-
-In case of an editorial conflict between the two specifications for a shared production, IDTA-01002 is authoritative. Bugfixes to shared productions in IDTA-01002 are automatically inherited by IDTA-01004.
-====
-
 .Access Rule Model
 [[image-access-rule-model]]
 [plantuml,mage-access-rule-model,svg]

--- a/documentation/IDTA-01004/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/changelog.adoc
@@ -28,6 +28,7 @@ Minor Changes:
 
 Bugfixes:
 
+* fix: Aligned date/time extraction functions (`$dayOfWeek`, `$dayOfMonth`, `$month`, `$year`) in JSON Schema to accept all `dateTimeOperand` types per BNF grammar, and widened `timeLiteralPattern` to support fractional seconds.
 * changed: Fixed incorrect Fragment Field Identifiers in examples [#44 of Security Spec](https://github.com/admin-shell-io/aas-specs-security/issues/44)
 
 == Changes w.r.t. V3.0.2 vs. V3.0.1

--- a/documentation/IDTA-01004/modules/ROOT/partials/json/aas-queries-and-access-rules-schema.json
+++ b/documentation/IDTA-01004/modules/ROOT/partials/json/aas-queries-and-access-rules-schema.json
@@ -26,7 +26,7 @@
     },
     "timeLiteralPattern": {
       "type": "string",
-      "pattern": "^[0-9][0-9]:[0-9][0-9](:[0-9][0-9])?$"
+      "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?(\\.[0-9]+)?$"
     },
     "Value": {
       "type": "object",
@@ -74,16 +74,44 @@
           "$ref": "#/definitions/Value"
         },
         "$dayOfWeek": {
-          "$ref": "#/definitions/dateTimeLiteralPattern"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimeLiteralPattern"
+            },
+            {
+              "$ref": "#/definitions/attributeItem"
+            }
+          ]
         },
         "$dayOfMonth": {
-          "$ref": "#/definitions/dateTimeLiteralPattern"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimeLiteralPattern"
+            },
+            {
+              "$ref": "#/definitions/attributeItem"
+            }
+          ]
         },
         "$month": {
-          "$ref": "#/definitions/dateTimeLiteralPattern"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimeLiteralPattern"
+            },
+            {
+              "$ref": "#/definitions/attributeItem"
+            }
+          ]
         },
         "$year": {
-          "$ref": "#/definitions/dateTimeLiteralPattern"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimeLiteralPattern"
+            },
+            {
+              "$ref": "#/definitions/attributeItem"
+            }
+          ]
         }
       },
       "oneOf": [

--- a/documentation/IDTA-01004/modules/ROOT/partials/json/formulas-and-logical-expressions.json
+++ b/documentation/IDTA-01004/modules/ROOT/partials/json/formulas-and-logical-expressions.json
@@ -18,7 +18,7 @@
     },
     "timeLiteralPattern": {
       "type": "string",
-      "pattern": "^[0-9][0-9]:[0-9][0-9](:[0-9][0-9])?$"
+      "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?(\\.[0-9]+)?$"
     },
     "Value": {
       "type": "object",
@@ -66,16 +66,44 @@
           "$ref": "#/definitions/Value"
         },
         "$dayOfWeek": {
-          "$ref": "#/definitions/dateTimeLiteralPattern"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimeLiteralPattern"
+            },
+            {
+              "$ref": "#/definitions/attributeItem"
+            }
+          ]
         },
         "$dayOfMonth": {
-          "$ref": "#/definitions/dateTimeLiteralPattern"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimeLiteralPattern"
+            },
+            {
+              "$ref": "#/definitions/attributeItem"
+            }
+          ]
         },
         "$month": {
-          "$ref": "#/definitions/dateTimeLiteralPattern"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimeLiteralPattern"
+            },
+            {
+              "$ref": "#/definitions/attributeItem"
+            }
+          ]
         },
         "$year": {
-          "$ref": "#/definitions/dateTimeLiteralPattern"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/dateTimeLiteralPattern"
+            },
+            {
+              "$ref": "#/definitions/attributeItem"
+            }
+          ]
         }
       },
       "oneOf": [


### PR DESCRIPTION
## Summary

Add an IMPORTANT block to the Access Rule Model chapter that names IDTA-01002 (Query Language chapter and its JSON Schema) as the normative single source of truth for all shared formula productions.

## Problem

Today IDTA-01002 and IDTA-01004 ship duplicated BNF fragments and JSON Schema blocks for formula expressions (logical expressions, comparisons, FieldIdentifiers, value literals, type casts, `$match`/`$and`/`$or`/`$not`). The two copies are maintained in parallel but no text states which one is authoritative, which has led to recurring drift (e.g. `timeLiteralPattern`, `$dayOfWeek` refs, `supplementalSemanticIds`).

## Solution

- Add a normative `IMPORTANT` block right after the existing cross-reference to the Query Language chapter.
- State that formula productions are normatively defined in IDTA-01002.
- State that IDTA-01004 only adds Access-Rule-specific productions (`ACL`, `OBJECTS`, `RIGHTS`, `ACCESS`, `ROUTE`, `FILTER`, `DEFATTRIBUTES`, `DEFACLS`, `DEFOBJECTS`, `DEFFORMULAS`, ...) on top of the shared grammar.
- Clarify that bugfixes to shared productions in IDTA-01002 are automatically inherited by IDTA-01004.

## Affected files

- `documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc`

## Review notes

- Pure documentation change, no normative change to the grammar or schema content.
- Companion PR in `aas-specs-api` adds the mirrored normative subsection.

Refs: Review Finding T-01
