### PR TITLE
* Rephrased/revised ==Introduction.

### DIFF
--- a/documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc
@@ -30,7 +30,7 @@ Section <<json-serialization,JSON Serialization of Access Rule Model>> defines t
 
 The Access Rule Model allows to define Access Rules in a modular way, so that parts can be reused (see <<reusable-definitions>>).
 
-Whether an Access Rule becomes active or not is decided by Formulas  <<conditions-and-formulas>>. Only if the overall result of the Formula is valid and true, the Access Rule becomes active. A formula can include nested boolean expressions, comparisons and string operations. A dedicated match operation allows to work with tuples in lists, e.g. specificAssetId.
+Whether an Access Rule becomes active or not is decided by Formulas  <<formulas>>. Only if the overall result of the Formula is valid and true, the Access Rule becomes active. A formula can include nested boolean expressions, comparisons and string operations. A dedicated match operation allows to work with tuples in lists, e.g. specificAssetId.
 
 Access SHALL only be granted if there is (at least) one access rule which allows the requested action on the designated AAS object (Route/Identifiable/Referable/Fragment/Descriptor; see <<objects>>). If there is no access rule, the default behavior shall be to deny access.
 
@@ -45,9 +45,9 @@ The access rule model can be used as a guideline which shows, what a client appl
 
 If an AAS implementation allows the exchange of access rules, it SHOULD follow the specification of the access rule model.
 
-AAS implementations MAY decide to support only a subset of the access rules. If an AAS implementation, e.g., only provides a READ profile, only such access rules for defining READ access are required. Access control MAY also be limited to specific subsystems, e.g., AAS repository, submodel respository, concept description repository, AAS registry or submodel registry.
+AAS implementations MAY decide to support only a subset of the access rules. If an AAS implementation, e.g., only provides a READ profile, only such access rules for defining READ access are required. Access control MAY also be limited to specific subsystems, e.g., AAS repository, submodel repository, concept description repository, AAS registry or submodel registry.
 
-AAS systems are supposed to deal with a large amount of AAS and AAS Submodels. To reach the needed performance and meet memory and storage constraints an AAS implemenation MAY translated the access rules into a representation that meets the needs of the respective implementation as long as the behavior complies to the stated rules.
+AAS systems are supposed to deal with a large amount of AAS and AAS Submodels. To reach the needed performance and meet memory and storage constraints an AAS implementation MAY translated the access rules into a representation that meets the needs of the respective implementation as long as the behavior complies to the stated rules.
 
 .Access Rule Model
 [[image-access-rule-model]]
@@ -68,9 +68,9 @@ An Identity Provider MAY also give the possibility to federate identities to/fro
 Trust means, that for such Identity Provider(s) an AAS Data Server can verify the public key of the Identity Provider.
 Such public key MAY be available directly as a key, by a public certificate or by a verifiable credential.
 
-The policy of a Dataspace SHALL define which access tokens are trusted by the AAS.
+The policy of a dataspace SHALL define which access tokens are trusted by the AAS.
 
-The policy of a Dataspaces SHALL define the set of subject ABAC attributes that are used as claims to determine authorization.
+The policy of a dataspaces SHALL define the set of subject ABAC attributes that are used as claims to determine authorization.
 
 Access tokens used for operations resulting in modification of information or disclosure of non-public information provided by the AAS shall use a state-of-the-art, cryptographically strong asymmetric signature scheme to authenticate the access token <<@todo use-of-cryptography>>.
 
@@ -85,14 +85,14 @@ Other properties like the lifetime of the token or Proof-of-Possession (RFC 7800
 AAS Security only requires the standard claims of the RFC 9068 Chapter 2.2 Data Structure for the JWT, i.e “iss” (Issuer), “exp” (Expiration time), “aud” (Audience), “sub” (Subject), “client_id” (Client identifier), “iat” (Issued at), “jti” (JWT ID).
 
 The  specific requirements on “iss”, “sub” and “aud” SHOULD be defined by the dataspace policy.
-//@todo I'd rather put a SHALL there. Messign up subject semantics breaks the whole access control model.
+//@todo I'd rather put a SHALL there. Messing up subject semantics breaks the whole access control model.
 
 All claims in an Access Token can be used in ABAC access rules as attributes and as described in the Access Rule Model below.
 
 Access rules can also be defined for anonymous access, i.e. no Access Token exists. +
 This is especially important for the Digital Product Passport to be able to scan the QRCODE according to IEC 61406 with a normal mobile phone camera.
 
-Further definitions can be made by dataspaces. A specific dataspace MAY define the technology how to get an access token and MAY also define the attributes which can be used in the ABAC access rules. Examples are discussed in <<identity-providers>>, <<authentication-flows>>.
+Further definitions can be made by dataspaces. A specific dataspace MAY define the technology how to get an access token and MAY also define the attributes which can be used in the ABAC access rules. Examples are discussed in xref:introduction.adoc#identity-providers[Identity Providers], xref:introduction.adoc#authentication-flows[Authentication Flows].
 
 This both assures interoperability and makes it possible to integrate new dataspaces in the future.
 
@@ -147,7 +147,7 @@ Objects to be protected are either API Routes, Identifiables (e.g. AAS or Submod
 An Access Rule Model <AllAccessPermissionRules> defines a list of <<access-permission-rules,Access Permission Rules>>.
 
 The access rule model <AllAccessPermissionRules> also contains lists of Attribute Groups <DEFATTRIBUTES>, Object Groups <DEFOBJECTS>, ACLs <DEFACLS> and Formulas <DEFFORMULAS>.
-These pre-defines can be referred to from other parts of the access control rules by the assigned <StringLiteral>. This allows to reuse commonly used definitions instead of having multiple copies spread over the access control rules. See <<reusable-definitions,Reusable Definitions>>.
+These pre-defines can be referred to from other parts of the access control rules by the assigned <StringLiteral>. This allows to reuse commonly used definitions instead of having multiple copies spread over the access control rules. See <<reusable-definitions>>.
 
 .Railroad diagram for <AllAccessPermissionRules>
 [[image-access-control-rules-model]]

--- a/documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc
@@ -13,42 +13,40 @@ SPDX-License-Identifier: CC-BY-4.0
 == General
 
 The introduction in Chapter xref:introduction.adoc[] has explained in detail the background for AAS Security. 
-The use of Identity Providers and Authentication Flows have been shown, which provide an access token to the client user application.
-Such access token contains claims as subject attributes which can be used in the Access Rule Model as defined below.
+The use of Identity Providers and Authentication Flows have been shown, which provide an access token to the client user application. Such access token contains claims as subject attributes which can be used in the Access Rule Model as defined below. In addition, the Access Rule Model contains further ABAC attributes like global attributes (also called environmental attributes) or object attributes.
 
-In addition, the Access Rule Model contains further ABAC attributes like global attributes (also called environmental attributes) or object attributes.
+ABAC attributes assessed by the AAS interface shall originate from a trustworthy source.
+
+Attributes derived from data represented by the AAS (e.g., value of a SubmodelElement) are assumed to be implicitly trusted by the AAS interface.
+
+Global attributes shall originate from a trustworthy source and their authenticity shall be protected (e.g., using a trusted local clock, relying on a trusted time service).
+
+Subject attributes need to be mapped to the subject in an authenticated way. This functionality must be provided by the PIP. The AAS interface relies on access tokens to convey subject attributes <<access-tokens>>.
 
 <<image-access-rule-model>> gives an overview of the Access Rule Model.
 Section <<bnf-grammar>> defines the text serialization of the Access Rule Model.
 Section <<json-serialization>> defines the JSON schema of the Access Rule Model.
 
-The Access Rule Model allows to define Access Rules in a modular way, so that parts can be reused.
+The Access Rule Model allows to define Access Rules in a modular way, so that parts can be reused (see <<reusable-definitions>>).
 
-* Attribute Groups can be defined to reuse combinations of attributes.
-* Object Groups can be defined to reuse combinations of objects.
-* Access Control Lists (ACLs) can be defined to reuse combinations of attributes and access rights.
+Whether an Access Rule becomes active or not is decided by Formulas  <<conditions-and-formulas>>. Only if the overall result of the Formula is valid and true, the Access Rule becomes active. A formula can include nested boolean expressions, comparisons and string operations. A dedicated match operation allows to work with tuples in lists, e.g. specificAssetId.
 
-Each Access Rule can define an own ACL or reuse an existing one.
-Each Access Rule can provide access to single objects or object groups.
-Each Access Rule can define an own Formula or reuse an existing one.
+Access SHALL only be granted if there is (at least) one access rule which allows the requested action on the designated AAS object (Route/Identifiable/Referable/Fragment/Descriptor; see <<objects>>). If there is no access rule, the default behavior shall be to deny access.
 
-The formula decides, if an Access Rule becomes active or not.
-Only if the overall result of the Formula is valid and true, the Access Rule becomes active.
-A formula can include nested boolean expressions, comparisons and string operations.
-A special operation match allows to work with tuples in lists, e.g. specificAssetId.
-
-Access shall only be granted if there is (at least) one access rule which allows the requested action on the designated AAS object (Route/Identifiable/Referable/Fragment/Descriptor).
-If there is no access rule, the default behavior shall be to deny access.
-
-
-This grammar handles both respositories and registries. 
-The symbol FieldIdentifier allows to use attributes of
-AAS, Submodel, SubmodelElement, ConceptDescription, AAS-Descriptor and Submodel-Descriptor. 
-Depending on the type of repository or registry such attributes are allowed or not.
-
+This grammar applies to both, respositories and registries.
+The symbol FieldIdentifier allows to use attributes of AAS, Submodel, SubmodelElement, ConceptDescription, AAS-Descriptor and Submodel-Descriptor.  Depending on the type of repository or registry such attributes are allowed or not.
 
 The AAS Query Language and the AAS Access Rules share the same BNF grammar for formula expressions.
 In addition to the text below, the further details of the formula expressions are explained in  link:https://industrialdigitaltwin.io/aas-specifications/IDTA-01002/v3.1/query-language.html[IDTA-01002, Query Language] .
+
+AAS implementations MAY decide, to which extent the access rule model is used.
+The access rule model can be used as a guideline which shows, what a client application will expect.
+
+If an AAS implementation allows the exchange of access rules, it SHOULD follow the specification of the access rule model.
+
+AAS implementations MAY decide to support only a subset of the access rules. If an AAS implementation, e.g., only provides a READ profile, only such access rules for defining READ access are required. Access control MAY also be limited to specific subsystems, e.g., AAS repository, submodel respository, concept description repository, AAS registry or submodel registry.
+
+AAS systems are supposed to deal with a large amount of AAS and AAS Submodels. To reach the needed performance and meet memory and storage constraints an AAS implemenation MAY translated the access rules into a representation that meets the needs of the respective implementation as long as the behavior complies to the stated rules.
 
 .Access Rule Model
 [[image-access-rule-model]]
@@ -56,6 +54,46 @@ In addition to the text below, the further details of the formula expressions ar
 ....
 include::partial$diagrams/access-rule-model.puml[]
 ....
+
+[[access-tokens]]
+== Access Tokens
+
+The evaluation of access rules to determine access to the AAS relies on access tokens to convey subject attributes.
+An access token is an authenticated set of claims about ABAC attributes that were mapped to the subject accessing the AAS. The access token is typically obtained using an Identity Provider. The access token is presented to the AAS along with the API request.
+
+An AAS Data Server trusts one or several Identity Providers.
+An Identity Provider MAY also give the possibility to federate identities to/from other Identity Providers.
+
+Trust means, that for such Identity Provider(s) an AAS Data Server can verify the public key of the Identity Provider.
+Such public key MAY be available directly as a key, by a public certificate or by a verifiable credential.
+
+The policy of a Dataspace SHALL define which access tokens are trusted by the AAS.
+
+The policy of a Dataspaces SHALL define the set of subject ABAC attributes that are used as claims to determine authorization.
+
+Access tokens used for operations resulting in modification of information or disclosure of non-public information provided by the AAS shall use a state-of-the-art, cryptographically strong asymmetric signature scheme to authenticate the access token <<@todo use-of-cryptography>>.
+
+AAS Security uses signed JWT (JSON Web Token) bearer tokens as Access Tokens, as they are defined in RFC 7519.
+
+The JWT is digitally signed according to RFC 7519 with the private key of the Identity Provider.
+The public key used as trust anchor needs to be accessible by the AAS server, such that the JWT can be verified.
+
+Other properties like the lifetime of the token or Proof-of-Possession (RFC 7800) properties SHOULD be determined based on the use case.
+//@todo IEC has a more strict requirement here: The life-time of an access token shall be limited.
+
+AAS Security only requires the standard claims of the RFC 9068 Chapter 2.2 Data Structure for the JWT, i.e “iss” (Issuer), “exp” (Expiration time), “aud” (Audience), “sub” (Subject), “client_id” (Client identifier), “iat” (Issued at), “jti” (JWT ID).
+
+The  specific requirements on “iss”, “sub” and “aud” SHOULD be defined by the dataspace policy.
+//@todo I'd rather put a SHALL there. Messign up subject semantics breaks the whole access control model.
+
+All claims in an Access Token can be used in ABAC access rules as attributes and as described in the Access Rule Model below.
+
+Access rules can also be defined for anonymous access, i.e. no Access Token exists. +
+This is especially important for the Digital Product Passport to be able to scan the QRCODE according to IEC 61406 with a normal mobile phone camera.
+
+Further definitions can be made by dataspaces. A specific dataspace MAY define the technology how to get an access token and MAY also define the attributes which can be used in the ABAC access rules. Examples are discussed in <<identity-providers>>, <<authentication-flows>>.
+
+This both assures interoperability and makes it possible to integrate new dataspaces in the future.
 
 == Grammar for Access Rule Model
 

--- a/documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/access-rule-model.adoc
@@ -72,7 +72,7 @@ The policy of a dataspace SHALL define which access tokens are trusted by the AA
 
 The policy of a dataspaces SHALL define the set of subject ABAC attributes that are used as claims to determine authorization.
 
-Access tokens used for operations resulting in modification of information or disclosure of non-public information provided by the AAS shall use a state-of-the-art, cryptographically strong asymmetric signature scheme to authenticate the access token <<@todo use-of-cryptography>>.
+Access tokens used for operations resulting in modification of information or disclosure of non-public information provided by the AAS shall use a state-of-the-art, cryptographically strong asymmetric signature scheme to authenticate the access token xref:requirements.adoc#use-of-cryptography[Use of Cryptography].
 
 AAS Security uses signed JWT (JSON Web Token) bearer tokens as Access Tokens, as they are defined in RFC 7519.
 
@@ -697,8 +697,8 @@ When AAS content is passed from one partner to another, this is typically relate
 In addition to the AAS content itself, also the defined access permissions have to be transferred between the partners due to the following two reasons:
 
 [arabic]
-. Access permissions to information elements of an AAS MUST be established in each access control domain.
-. One partner MUST be able to pass a suggestion which access permissions SHOULD be established for the asset that is described in the AAS.
+. Access permissions to information elements of an AAS must be established in each access control domain.
+. One partner must be able to pass a suggestion which access permissions should be established for the asset that is described in the AAS.
 
 ABAC is a very flexible approach, that also encompasses role-based access as a role can be considered as one attribute in this context.
 Other attributes might be the time-of-day, the location of the asset, the originating address and others.

--- a/documentation/IDTA-01004/modules/ROOT/pages/annex/requirements_mapping.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/annex/requirements_mapping.adoc
@@ -10,7 +10,7 @@ The full set of IEC 62443 requirements needs to be reconsidered for additional s
 [cols="1,1,^1,^1,^1,1"]
 [[table_assessment_fr1]]
 |===
-|FR|Title|IEC 63278-3-3 SR|IEC 63278-4-2 CR|Applicable to IDTA 01001 xref:../bibliography.adoc#bib1[[1\]], IDTA 01002 xref:../bibliography.adoc#bib2[[2\]], IDTA 01003-a xref:../bibliography.adoc#bib3[[3\]]|IDTA 01004 clause or comment
+|FR|Title|IEC 62443-3-3 SR|IEC 62443-4-2 CR|Applicable to IDTA 01001 xref:../bibliography.adoc#bib1[[1\]], IDTA 01002 xref:../bibliography.adoc#bib2[[2\]], IDTA 01003-a xref:../bibliography.adoc#bib3[[3\]]|IDTA 01004 clause or comment
 
 |1.1
 |Human user, process and device identification and authentication
@@ -119,7 +119,7 @@ It is possible to use public key certificates to meet authentication requirement
 [cols="1,1,^1,^1,^1,1"]
 [[table_assessment_fr2]]
 |===
-|FR|Title|IEC 63278-3-3 SR|IEC 63278-4-2 CR|Applicable to IDTA 01001 xref:../bibliography.adoc#bib1[[1\]], IDTA 01002 xref:../bibliography.adoc#bib2[[2\]], IDTA 01003-a xref:../bibliography.adoc#bib3[[3\]]|IDTA 01004 clause or comment
+|FR|Title|IEC 62443-3-3 SR|IEC 62443-4-2 CR|Applicable to IDTA 01001 xref:../bibliography.adoc#bib1[[1\]], IDTA 01002 xref:../bibliography.adoc#bib2[[2\]], IDTA 01003-a xref:../bibliography.adoc#bib3[[3\]]|IDTA 01004 clause or comment
 
 |2.1
 |Authorization enforcement
@@ -220,7 +220,7 @@ xref:../accountability.adoc#_accountability[Accountability for AAS Content and D
 [cols="1,1,^1,^1,^1,1"]
 [[table_assessment_fr3]]
 |===
-|FR|Title|IEC 63278-3-3 SR|IEC 63278-4-2 CR|Applicable to IDTA 01001 xref:../bibliography.adoc#bib1[[1\]], IDTA 01002 xref:../bibliography.adoc#bib2[[2\]], IDTA 01003-a xref:../bibliography.adoc#bib3[[3\]]|IDTA 01004 clause or comment
+|FR|Title|IEC 62443-3-3 SR|IEC 62443-4-2 CR|Applicable to IDTA 01001 xref:../bibliography.adoc#bib1[[1\]], IDTA 01002 xref:../bibliography.adoc#bib2[[2\]], IDTA 01003-a xref:../bibliography.adoc#bib3[[3\]]|IDTA 01004 clause or comment
 
 |3.1
 |Communication integrity
@@ -334,7 +334,7 @@ xref:../requirements.adoc#_aas_roots_of_trust_management[AAS roots of trust mana
 [cols="1,1,^1,^1,^1,1"]
 [[table_assessment_fr4]]
 |===
-|FR|Title|IEC 63278-3-3 SR|IEC 63278-4-2 CR|Applicable to IDTA 01001 xref:../bibliography.adoc#bib1[[1\]], IDTA 01002 xref:../bibliography.adoc#bib2[[2\]], IDTA 01003-a xref:../bibliography.adoc#bib3[[3\]]|IDTA 01004 clause or comment
+|FR|Title|IEC 62443-3-3 SR|IEC 62443-4-2 CR|Applicable to IDTA 01001 xref:../bibliography.adoc#bib1[[1\]], IDTA 01002 xref:../bibliography.adoc#bib2[[2\]], IDTA 01003-a xref:../bibliography.adoc#bib3[[3\]]|IDTA 01004 clause or comment
 
 |4.1
 |Information confidentiality
@@ -364,7 +364,7 @@ xref:../requirements.adoc#_aas_roots_of_trust_management[AAS roots of trust mana
 [cols="1,1,^1,^1,^1,1"]
 [[table_assessment_fr5]]
 |===
-|FR|Title|IEC 63278-3-3 SR|IEC 63278-4-2 CR|Applicable to IDTA 01001 xref:../bibliography.adoc#bib1[[1\]], IDTA 01002 xref:../bibliography.adoc#bib2[[2\]], IDTA 01003-a xref:../bibliography.adoc#bib3[[3\]]|IDTA 01004 clause or comment
+|FR|Title|IEC 62443-3-3 SR|IEC 62443-4-2 CR|Applicable to IDTA 01001 xref:../bibliography.adoc#bib1[[1\]], IDTA 01002 xref:../bibliography.adoc#bib2[[2\]], IDTA 01003-a xref:../bibliography.adoc#bib3[[3\]]|IDTA 01004 clause or comment
 
 |5.1
 |Network segmentation
@@ -400,7 +400,7 @@ xref:../requirements.adoc#_aas_roots_of_trust_management[AAS roots of trust mana
 [cols="1,1,^1,^1,^1,1"]
 [[table_assessment_fr6]]
 |===
-|FR|Title|IEC 63278-3-3 SR|IEC 63278-4-2 CR|Applicable to IDTA 01001 xref:../bibliography.adoc#bib1[[1\]], IDTA 01002 xref:../bibliography.adoc#bib2[[2\]], IDTA 01003-a xref:../bibliography.adoc#bib3[[3\]]|IDTA 01004 clause or comment
+|FR|Title|IEC 62443-3-3 SR|IEC 62443-4-2 CR|Applicable to IDTA 01001 xref:../bibliography.adoc#bib1[[1\]], IDTA 01002 xref:../bibliography.adoc#bib2[[2\]], IDTA 01003-a xref:../bibliography.adoc#bib3[[3\]]|IDTA 01004 clause or comment
 
 |6.1
 |Audit log accessibility
@@ -422,7 +422,7 @@ xref:../requirements.adoc#_aas_roots_of_trust_management[AAS roots of trust mana
 [cols="1,1,^1,^1,^1,1"]
 [[table_assessment_fr7]]
 |===
-|FR|Title|IEC 63278-3-3 SR|IEC 63278-4-2 CR|Applicable to IDTA 01001 xref:../bibliography.adoc#bib1[[1\]], IDTA 01002 xref:../bibliography.adoc#bib2[[2\]], IDTA 01003-a xref:../bibliography.adoc#bib3[[3\]]|IDTA 01004 clause or comment
+|FR|Title|IEC 62443-3-3 SR|IEC 62443-4-2 CR|Applicable to IDTA 01001 xref:../bibliography.adoc#bib1[[1\]], IDTA 01002 xref:../bibliography.adoc#bib2[[2\]], IDTA 01003-a xref:../bibliography.adoc#bib3[[3\]]|IDTA 01004 clause or comment
 
 |7.1
 |Denial of service protection

--- a/documentation/IDTA-01004/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/changelog.adoc
@@ -11,7 +11,7 @@ SPDX-License-Identifier: CC-BY-4.0
 [[change-notes]]
 = Change Notes
 
-== Changes w.r.t. V3.1 vs. V3.0.1
+== Changes w.r.t. V3.1 vs. V3.0.2
 
 Major Changes:
 
@@ -20,6 +20,8 @@ Major Changes:
 * changed: DateTime and Time literals in access rules now use explicit patterns based on AAS core meta `MatchesXsDateTime` and `MatchesXsTime`, which correspond to the XSD-based data types defined by the IDTA 01001 Part 1 Metamodel and are based on XML Schema `xs:dateTime`/`xs:time`/ISO 8601 lexical forms. Values require seconds, may include fractional seconds and timezone offsets, Time values without timezone information are interpreted as UTC, and incomplete values such as `09:00` need to be completed before serialization, e.g. `09:00:00Z`. Calendar-specific invalid dates still need semantic validation beyond the lexical day, month and year ranges. [#63](https://github.com/admin-shell-io/aas-specs-security/issues/63)
 * added: Query Filter and FragmentFieldIdentifiers (https://github.com/admin-shell-io/aas-specs-api/issues/517)
 * added: new section in the annex on access control management and data authentification for implementing the digital product passport (DPP)
+* added: Added chapter requirements.adoc and annex/requirements_mapping.adoc
+* changed: Avoided provisional verbs in introduction.adoc, essential provision text has been moved to acccess-rule-model.adoc
 
 Minor Changes:
 
@@ -29,6 +31,10 @@ Minor Changes:
 * added: Clarified <ReferenceAttribute> semantics and added a state-dependent filtering example where maintenance documents are filtered using machine state read via REFERENCE from another Submodel.
 * added: Clarified ROUTE semantics for AAS HTTP/REST path matching and added informative ROUTE and request examples [#58](https://github.com/admin-shell-io/aas-specs-security/issues/58)
 * added: Expanded the explanation of RIGHTS with a mapping to operation verbs and HTTP methods, including an illustrative table and diagram [#56](https://github.com/admin-shell-io/aas-specs-security/issues/56)
+* moved: Moved and revised protection goals from introduction to own chapter
+* updated: Editorial changes to the explanation of the access rule BNF
+* added: Clarification of semver usage
+
 
 Bugfixes:
 
@@ -37,6 +43,7 @@ Bugfixes:
 * fix: Aligned date/time extraction functions (`$dayOfWeek`, `$dayOfMonth`, `$month`, `$year`) in JSON Schema to accept all `dateTimeOperand` types per BNF grammar.
 * fix: Aligned comparison and cast operands in JSON Schema with BNF semantics, including boolean equality-only comparisons, ordered comparisons without boolean operands, restricted `$dateTimeCast`/`$timeCast` inputs, and no raw `$boolean` inside `$match`.
 * changed: Fixed incorrect Fragment Field Identifiers in examples [#44 of Security Spec](https://github.com/admin-shell-io/aas-specs-security/issues/44)
+* fix: access rule BNF
 
 == Changes w.r.t. V3.0.2 vs. V3.0.1
 

--- a/documentation/IDTA-01004/modules/ROOT/pages/introduction.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/introduction.adoc
@@ -25,7 +25,7 @@ In case of switching between AAS implementations, an exchange of access rules is
 
 AAS implementations (of non test systems) are supposed to consider relevant security standards and regulations, e.g. IEC 62443, ISO 27001, EU CRA or EU NIS2. This includes rules for the development process and for the written code.
 
-Section @todo requirements.adoc defines security requirements for AAS systems following the IEC 63443 series. Implementation specific security requirements are not part of this document. Annex @todo provides an overview on which requirements are addressed by this document and which are not.
+Section xref:requirements.adoc[Requirements] defines security requirements for AAS systems following the IEC 63443 series. Implementation specific security requirements are not part of this document. The Annex xref:annex/requirements_mapping.adoc[Requirements Mapping] provides an overview on which requirements are addressed by this document and which are not.
 
 Typical scenarious for AAS include multiple stakeholders along the industrial value chain. This comes with the need for authentication and authorization of subjects, i.e., users and systems, accross different security domains. This is addressed by identity and access management (IAM). This document dicusses several patterns and examples for IAM in the context of AAS (<<integration-patterns>>,<<identity-providers>>, <<authentication-flows>>). However, this document does not mandate a specific solution for IAM. As a result of the subject identification and authentication process there is an Access Token that is evaluated by the AAS to authorize access to data and services represented by the AAS.
 
@@ -39,12 +39,12 @@ Access rules are defined for routes in the AAS API xref:bibliography.adoc#bib2[[
 As introduced in AAS Part 2 API, <<image-aas-info-exchange-types>> shows 3 different types of information via the Asset Administration Shell.
 
 * Type 1 is the exchange as an AASX file xref:bibliography.adoc#bib3[[3\]] (part 5).
-Such AASX file CAN include a Security Model to be passed to a business partner.
+Such AASX file can include a Security Model to be passed to a business partner.
 * Type 2 is the access to AAS by the API xref:bibliography.adoc#bib2[[2\]] (part 2) to a server.
-Such server CAN use and enforce the ABAC rules of the Security Model.
-The Security Model MAY be hosted as submodel by the server. The submodel for the Security Model is then itself subject to access control.
+Such server can use and enforce the ABAC rules of the Security Model.
+The Security Model may be hosted as submodel by the server. The submodel for the Security Model is then itself subject to access control.
 * Type 3 is the so called “Industrie 4.0 Language” with active AAS, which is similar to agents.
-Basically Type 3 is out of scope for this document, but the definitions of this document CAN also be used in the context of Type 3.
+Basically Type 3 is out of scope for this document, but the definitions of this document can also be used in the context of Type 3.
 
 .Types of Information Exchange via Asset Administration Shells
 [[image-aas-info-exchange-types]]
@@ -67,7 +67,7 @@ The technology-neutral level comprises the following concepts:
 
 * *Service*: a service describes a demarcated scope of functionality (including its informational and non-functional aspects), which is offered by an entity or organization via interfaces.
 * *Interface*: this is the most important concept as it is understood to be the unit of reusability across services and the unit of standardization when mapped to application programming interfaces (API) in the technology-specific level.
-One interface MAY be mapped to several APIs depending on the technology and architectural style used, e.g. HTTP/REST or OPC UA, whereby these API mappings also need to be standardized for the sake of interoperability.
+One interface may be mapped to several APIs depending on the technology and architectural style used, e.g. HTTP/REST or OPC UA, whereby these API mappings also need to be standardized for the sake of interoperability.
 * *Interface-Operation*: interface operations define interaction patterns via the specified interface.
 
 The technology-specific level comprises the following concepts:
@@ -77,16 +77,16 @@ Among others, it comprises and refers to the list of APIs that forms this servic
 The service specification includes I4.0-defined standard APIs but also other, proprietary APIs.
 
 ====
-Note: such a technology-specific service specification MAY be but does not have to be derived from the “service” described in the technology-neutral form.
+Note: such a technology-specific service specification may be but does not have to be derived from the “service” described in the technology-neutral form.
 It is up to the system architect and service engineer to tailor the technology-specific service according to the needs of the use cases.
 ====
 
 * *API*: specification of the set of operations and events that forms an API in a selected technology.
 It is derived from the interface description on the technology-neutral level.
-Hence, if there are several selected technologies, one interface MAY be mapped to several APIs.
+Hence, if there are several selected technologies, one interface may be mapped to several APIs.
 * *API-Operation*: specification of the operations (procedures) that are accessible through an API.
 It is derived from the interface operation description on the technology-neutral level.
-When selecting technologies, one interface operation MAY be mapped to several API-operations; several interface operations MAY also be mapped to the same API-operation.
+When selecting technologies, one interface operation may be mapped to several API-operations; several interface operations may also be mapped to the same API-operation.
 
 The implementation level comprises the following concepts:
 
@@ -142,7 +142,7 @@ It is up to the integrator to forward only selected submodels from the supplier'
 
 This use case is an example for the necessity of Signing, since it is desireable to check the integrity of the AAS originally provided by the supplier.
 
-<<@todo accountability>> discusses means of ensuring accountability of AAS data. Basic signing functionality for data retrieval from an AAS is defined in REST API specification.
+Chapter xref:../accountability.adoc#_accountability[Accountability for AAS Content and Digital Signatures] discusses means of ensuring accountability of AAS data. Basic signing functionality for data retrieval from an AAS is defined in the REST API specification link:https://industrialdigitaltwin.io/aas-specifications/IDTA-01002/v3.2[IDTA-01002].
 
 .Use Case File Exchange between Value Chain Partners
 [[image-tracking-of-changes-via-events]]

--- a/documentation/IDTA-01004/modules/ROOT/pages/introduction.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/introduction.adoc
@@ -17,44 +17,34 @@ This specification defines a model for access rules. Such model targets 2 purpos
 Purpose 1 is to provide guidelines for implementations.
 
 Purpose 2 is to address the definition and exchange of access rules.
-Such exchange of access rules is very useful for complex assets like robot or machine.
-The supplier of an asset MAY already supply a set of access rules, which the operator of the asset MAY simply adjust then.
+
+The exchange of access rules is very useful for complex assets like robot or machine.
+A set of access rules is provided by the supplier of an asset and the operator adjusts the access rules to his needs.
+
 In case of switching between AAS implementations, an exchange of access rules is useful.
 
-AAS implementations MAY decide, to which extent the access rule model is used.
-The access rule model can be used as a guideline which shows, what a client application will expect.
-If an AAS implementation allows the exchange of access rules, it SHOULD follow the specification of the access rule model.
+AAS implementations (of non test systems) are supposed to consider relevant security standards and regulations, e.g. IEC 62443, ISO 27001, EU CRA or EU NIS2. This includes rules for the development process and for the written code.
 
-AAS implementations MAY decide, which subset of the access rules is implemented.
-If an AAS implementation e.g. only provides a READ profile, only such access rules for READ SHALL be allowed.
-Further subsets can be e.g. AAS repository, submodel respository, concept description repository, AAS registry or submodel registry.
+Section @todo requirements.adoc defines security requirements for AAS systems following the IEC 63443 series. Implementation specific security requirements are not part of this document. Annex @todo provides an overview on which requirements are addressed by this document and which are not.
 
-AAS implementations (of non test systems) SHOULD consider relevant security standards and regulations, e.g. IEC 62443, ISO 27001, EU CRA or EU NIS2.
-This includes rules for the development process and for the written code.
-AAS implementations MAY provide millions of AAS. In such case, access rules are typically translated into the related AAS implementation to reach the needed perfomance and fulfill memory constraints.
+Typical scenarious for AAS include multiple stakeholders along the industrial value chain. This comes with the need for authentication and authorization of subjects, i.e., users and systems, accross different security domains. This is addressed by identity and access management (IAM). This document dicusses several patterns and examples for IAM in the context of AAS (<<integration-patterns>>,<<identity-providers>>, <<authentication-flows>>). However, this document does not mandate a specific solution for IAM. As a result of the subject identification and authentication process there is an Access Token that is evaluated by the AAS to authorize access to data and services represented by the AAS.
 
-Access Tokens to be used with the Asset Administration Shell are defined.
-Such Access Token is the result of an authentication flow which is not defined by this document.
-Important authentication flows are explained in this clause in <<authentication-flows>>.
+An Access Rule Model is defined, which uses Attribute Based Access Control (<<ABAC>>) as underlying concept.
+Claims carried by the Access Token are used as attributes for the ABAC authorization. ABAC allows to consider additional attributes which go beyond subject identity or role for authorization decisions. Date and time of the requiest, current machine state, environmental conditions are examples for additional attributes.
 
-An Access Rule Model is defined, which uses Attribute Based Access Control (ABAC) as underlying concept.
-Claims of an Access Token are used as attributes for the ABAC authorization.
-Further attributes as DATETIME or machine state can also be included in the authorization.
-
-Access rules can be defined for routes in the AAS API xref:bibliography.adoc#bib2[[2\]] (part 2), for Identifiables and Referables by reference or semanticId, or for certain assets.
+Access rules are defined for routes in the AAS API xref:bibliography.adoc#bib2[[2\]] (part 2), for Identifiables and Referables by reference or semanticId, or for certain assets.
 
 == Types of AAS
 
 As introduced in AAS Part 2 API, <<image-aas-info-exchange-types>> shows 3 different types of information via the Asset Administration Shell.
 
 * Type 1 is the exchange as an AASX file xref:bibliography.adoc#bib3[[3\]] (part 5).
-Such AASX file MAY include a Security Model to be passed to a business partner.
+Such AASX file CAN include a Security Model to be passed to a business partner.
 * Type 2 is the access to AAS by the API xref:bibliography.adoc#bib2[[2\]] (part 2) to a server.
-Such server MAY use and enforce the ABAC rules of the Security Model.
-Depending on the access rules, such server MAY also allow to access the submodel with the Security Model by the API.
-Identifiables on the server MAY also be signed.
+Such server CAN use and enforce the ABAC rules of the Security Model.
+The Security Model MAY be hosted as submodel by the server. The submodel for the Security Model is then itself subject to access control.
 * Type 3 is the so called “Industrie 4.0 Language” with active AAS, which is similar to agents.
-Basically Type 3 is out of scope for this document, but the definitions of this document MAY also be used in the context of Type 3.
+Basically Type 3 is out of scope for this document, but the definitions of this document CAN also be used in the context of Type 3.
 
 .Types of Information Exchange via Asset Administration Shells
 [[image-aas-info-exchange-types]]
@@ -84,7 +74,7 @@ The technology-specific level comprises the following concepts:
 
 * *Service Specification*: specification of a service according to the notation, architectural style, and constraints of a selected technology.
 Among others, it comprises and refers to the list of APIs that forms this service specification.
-These MAY be I4.0-defined standard APIs but also other, proprietary APIs.
+The service specification includes I4.0-defined standard APIs but also other, proprietary APIs.
 
 ====
 Note: such a technology-specific service specification MAY be but does not have to be derived from the “service” described in the technology-neutral form.
@@ -94,7 +84,7 @@ It is up to the system architect and service engineer to tailor the technology-s
 * *API*: specification of the set of operations and events that forms an API in a selected technology.
 It is derived from the interface description on the technology-neutral level.
 Hence, if there are several selected technologies, one interface MAY be mapped to several APIs.
-* *API-Operation*: specification of the operations (procedures) that MAY be called through an API.
+* *API-Operation*: specification of the operations (procedures) that are accessible through an API.
 It is derived from the interface operation description on the technology-neutral level.
 When selecting technologies, one interface operation MAY be mapped to several API-operations; several interface operations MAY also be mapped to the same API-operation.
 
@@ -132,7 +122,7 @@ One important message from the Industrie 4.0 Service Model is that it is the lev
 
 An AAS descriptor includes the endpoint of the AAS and of the related Submodels.
 
-* AAS or Submodels MAY be hosted standalone or as part of a larger AAS or Submodel Repository.
+* AAS or Submodel are either hosted standalone or as part of a larger AAS or Submodel Repository.
 In <<image-seq-sm-endpoints>> the first submodel is accessed by the Submodel Interface and the second submodel is accessed by the Submodel Repository Interface.
 
 .Sequence Diagram of AAS Services
@@ -147,11 +137,12 @@ include::partial$diagrams/seq-sm-endpoints.puml[]
 <<image-tracking-of-changes-via-events>> shows an example use case of File Exchange between business partners as introduced by AAS Part 5 Package File.
 
 In the example a supplier sends AAS as AASX by email to an integrator.
-The integrator MAY send these AAS and additional own AAS to his customers.
-The integrator MAY also only select certain submodels from the supplier's AAS.
+The integrator sends the AAS received from the supplier and additional own AAS to his customers.
+It is up to the integrator to forward only selected submodels from the supplier's AAS to his customer.
 
-This use case is an example for the necessity of Signing, since it MUST be possible to check the integrity of the AAS originally provided by the supplier.
-Signing is defined in REST API specification.
+This use case is an example for the necessity of Signing, since it is desireable to check the integrity of the AAS originally provided by the supplier.
+
+<<@todo accountability>> discusses means of ensuring accountability of AAS data. Basic signing functionality for data retrieval from an AAS is defined in REST API specification.
 
 .Use Case File Exchange between Value Chain Partners
 [[image-tracking-of-changes-via-events]]
@@ -181,9 +172,7 @@ It will then access the data on the different AAS servers by the related APIs.
 
 This use case is an example for the necessity of Authentication, Authorization and Signing.
 
-The AAS Servers MAY provide data available to the public, i.e. anonymous users.
-But an AAS Server MAY also restrict the access of certain data to specific users.
-In such case the User Application MUST first authenticate (not in the figure) and get an Access Token to supply its identity and further attributes to an AAS Server and also to the Registry.
+The AAS Servers provide data available to the public, i.e. anonymous users, or restrict the access of certain data to specific users. To gain access to restricted data, the User Application first authenticates (not in the figure) and gets an Access Token to supply its identity and further attributes to an AAS Server and also to the Registry.
 Access rules will be validated and enforced using the attributes in the Access Token.
 
 .Example of a User Application accessing 3 AAS Servers and a Registry
@@ -229,12 +218,11 @@ include::partial$diagrams/aas-server-implementation.puml[]
 * First such access will be handled by the *API Gateway* in the *AAS Server*.
 Such *API Gateway* will verify the signature of the access token by the *Authentication Service*, which uses the public key of the *Identity Provider / Authorization Server*.
 * Second the *AAS API* verifies by the *Authorization Service*, that the requested API route is authorized.
-This MAY be defined by related ABAC access rules for that API route.
+Access is determined by related ABAC access rules for that API route.
 * Third the *AAS API* verifies by the *Authorization Service*, that the requested AAS element is authorized.
-This MAY be defined by related ABAC access rules with IDs of Identifiables, Referables, Assets or semanticIds.
+Access is determined by ABAC access rules with IDs of Identifiables, Referables, Assets or semanticIds.
 * Fourth the *AAS API* will access the *Data Storage*, but only in case of all the positive authorizations above.
-* The *AAS Responsible* MAY receive proposed ABAC access rules from his business partners, e.g. a machine supplier proposes such rules to a machine operator.
-Such access rules MAY be stored in a proprietary way by the *AAS Server*, but they might also be stored in the Data Storage in AAS format as received.
+* Business partners send proposed access rules to the *AAS Responsible*, e.g., a machine supplier proposes such rules to a machine operator. Whether such access rules are stored in a proprietary way by the *AAS Server*, or in the Data Storage in AAS format as received depends on the implementation.
 * As described for the *AAS Server*, the AAS *User Application* will also provide the access token to the *Discovery/Registry Service* which can make the verification and authorization accordingly.
 
 === Protecting an AAS Registry
@@ -257,11 +245,20 @@ include::partial$diagrams/aas-registry-implementation.puml[]
 The objective of access control is to protect system resources (here: AAS content) against unauthorized access.
 The protection measures are specified in access control policies whose scope of validity is defined by security domains dedicated to access control.
 
-The underlying concept applied for access control is the concept of attribute-based access control (ABAC).
-In general, the ABAC request flow is described in xref:bibliography.adoc#bib8[[8\]].
-Originally, ABAC relies upon the data-flow model and language model of the OASIS eXtensible Access Control Markup Language (XACML) specifications xref:bibliography.adoc#bib9[[9\]].
+AAS applications require effective management of data exposure. This is especially important if data is shared across multiple companies. Attribute based access control provides a means of addressing these requirements. Refer to xref:bibliography.adoc#bib8[[8\]] for further explanations of ABAC. Originally, ABAC relies upon the data-flow model and language model of the OASIS eXtensible Access Control Markup Language (XACML) specifications xref:bibliography.adoc#bib9[[9\]].
 
-OASIS XACML includes concepts such as: 
+Many existing systems for access control in IACS apply role based access control (RBAC). RBAC employs pre-defined roles. Each subject (AAS user application or AAS user application user in case of AAS) is assigned one or several roles. Each role comes with a set of privileges. Before access is allowed to an AAS object (6.2.4.5) it is checked whether the role associated with the requesting subject has sufficient privileges.
+The role assigned to a subject represents one specific attribute of that subject. This attribute “role” is typically derived from the subjects identity (5.2.2.1). ABAC extents the traditional concept of RBAC. ABAC it allows to use additional attributes other than the subject’s role in the evaluation of an access decision. It is still possible to stick with a single attribute “role” to maintain interoperability towards an RBAC environment.
+
+Each access decision within ABAC is taken based on a set of access control rules based on ABAC attributes:
+
+* Subject attributes, i.e., attributes of the subject requesting AAS information,
+e.g., identity, role/responsibility, affiliation of AAS user application or AAS user application user
+* AAS object attributes, i.e., attributes of the AAS object (6.2.4.5) being requested,
+e.g., semanticId of a Submodel, SubmodelElement, or Property.
+* Environmental conditions/global attributes, e.g., time at which an enquiry is made.
+
+A typical ABAC system is built around the following function blocks:
 
 * Policy administration point (PAP): The system entity that creates a policy set.
 * Policy decision point (PDP): The system entity that evaluates an applicable policy and renders an authorization decision.
@@ -281,7 +278,7 @@ image::abac.jpg[width=460,height=372]
 
 In this document the concept of attributes is specialized for the application of ABAC in the context of AAS authorization.
 
-Attributes MAY be claims from an access token (e.g. subject attributes), global attributes (e.g. environmental conditions) or attributes from AAS and submodel data (e.g. object attributes).
+Attributes are claims from an access token (e.g. subject attributes), global attributes (e.g. environmental conditions) or attributes from AAS and submodel data (e.g. object attributes).
 
 == Dataspaces
 
@@ -299,11 +296,11 @@ In a dataspace members can exchange data securely and interoperably.
 
 Such data exchange is always done in the same way, so that scalability and efficiency can be achieved.
 
-Millions of business partners SHALL be able to easily exchange data with each other in a dataspace.
+Millions of business partners are able to easily exchange data with each other in a dataspace.
 
 The data exchange can be with and without user interaction.
 
-To achieve interoperability, members of a dataspace MUST agree on:
+To achieve interoperability, members of a dataspace agree on:
 
 * Common models
 * Common APIs
@@ -328,13 +325,14 @@ In addition, a dataspace with AAS needs to define:
 Remark: Until now no common AAS specifications for the following concepts are published and need also to be defined in a dataspace with AAS:
 
 * How to find AAS registries of the dataspace members?
-Solutions MAY be a registry with registry endpoints or a naming convention like registry.company-domain.com.
+A solutions is to have a registry with registry endpoints or a naming convention like registry.company-domain.com.
 Also, an indirect registration via dataspace connectors that also support additional data exchange patterns besides AAS, e.g. simple bilateral file exchange, is possible.
 
 * How to find concept repositories?
 A solution can be a registry of concept repository endpoints or a concept repository discovery service for semantic IDs.
 Additional discovery services if needed, for example for the company-domain etc.
 
+[[integration-patterns]]
 == Integration Patterns
 
 With AAS many use cases between business partners are supported.
@@ -360,13 +358,11 @@ image::integration-patterns.jpg[width=602,height=228]
 The AAS is not accessible from outside the Company.
 - Everything can be decided internally by the company (Company A).
 - Company hosts AAS on a server internally.
-The server software MAY be open source, a commercial product or a software as a service.
-- Company will choose an Identity Provider, that is aligned with company’s IT infrastructure.
-Chosen server software MUST be able to support this.
-- Chosen server software MAY have predefined claims or MAY be fully configurable for claims.
-- Chosen server software MAY have certain limited access rules or MAY be fully configurable for access rules according standardized AAS security.
-- For many internal Use Cases the security MAY be complete company specific not using the standardized AAS security.
-Since the company MAY decide later to make their AAS available to other companies (pattern “Access to External”) or the company MAY use existing software to host their AAS, company MAY still benefit from using standardized AAS security.
+The server software is open source, a commercial product or a software as a service.
+- Company chooses an Identity Provider, that is aligned with company’s IT infrastructure. The chosen server software is configured to use this Identity Provider.
+- Chosen server software either supports a set of predefined claims or is fully configurable for claims.
+- Chosen server software either supports a limited set of build-in access rules or is fully configurable for access rules according standardized AAS security.
+- For many internal Use Cases the security is expected to be complete company specific and does not depend on using the standardized AAS security. However, if the company decides later to make their AAS available to other companies (pattern “Access to External”) or the company chooses to use existing software to host their AAS, the company does still benefit from using standardized AAS security.
 
 === Integration Pattern “Buy and Use” (IP2)
 
@@ -374,16 +370,16 @@ Since the company MAY decide later to make their AAS available to other companie
 - Company B has created the AAS and Company A copies the AAS.
 - The AAS is hosted on a server of company A.
 - Company A defines Identity Provider, access token and claims.
-- Company B MAY propose standardized AAS Access Rules to Company A, which Company A MAY simply copy and paste into his AAS Server.
+- Company B proposes a standard compliant AAS Access Rules to Company A, which Company A simply copies into his AAS Server.
 - With respect to security this case is very similar to the “Build My Own” access pattern.
 
 === Integration Pattern “Access to External” (IP3)
 
 - Company A accesses an AAS on an external server of Company B.
-- Company A MAY access AAS from one business partner (bilateral) or MAY access AAS from many different business partners (multilateral).
+- Company A accesses AAS from one business partner (bilateral) or accesses AAS from many different business partners (multilateral).
 - The external business partner Company B hosts his AAS on his server.
 - Company A accesses AAS by the API and uses it in its user applications.
-If the usage policy from Company B allows it, Company A MAY copy the AAS and store it in its own systems.
+If the usage policy from Company B allows it, Company A copies the AAS and store it in its own systems.
 - In case of bilateral access, Identity Provider, access token and claims are defined by Company B.
 - In case of multilateral access, a common Identity Provider of a dataspace is used.
 The members of the dataspace have to define access token and claims.
@@ -395,9 +391,10 @@ The members of the dataspace have to define access token and claims.
 - Company A has created the AAS and Company B copies the AAS.
 - The AAS is hosted on a server of company B.
 - Company B defines Identity Provider, access token and claims.
-- Company A MAY propose standardized AAS Access Rules to Company B, which Company B MAY simply copy and paste into his AAS Server.
+- Company A proposes a  AAS Access Rules to Company B, which Company B simply copies into his AAS Server.
 - With respect to security this case is similar to the bilateral “Access to External” access pattern.
 
+[[identity-providers]]
 == External and Internal Identity Providers
 
 A Secured System in AAS Security can be Discovery Service, Registry Service, AAS/Submodel Service or AAS/Submodel/ConceptDescription Repository Service.
@@ -445,7 +442,7 @@ In cases where a shared AAS/SM Registry references identifiables from different 
 
 From administration point of view, the Federated Identity Provider and the Token Exchange approach enable a system owner to fully control access to their secured systems, because the Identity Provider is managed by the system owner.
 
-A distributed identity layer MAY also be achieved via self-sovereign identity wallets.
+Self-sovereign identity wallets provide a way to achieve a distributed identity layer.
 
 [[authentication-flows]]
 == Authentication Flows
@@ -459,7 +456,7 @@ Authentication flows like OAUTH 2.0 or OIDC can be used.
 
 Authentication flows as defined by a specific dataspace or by a specific dataspace protocol can be used.
 
-In any case a signed JSON Web Token MUST be provided by the related Identity Provider.
+In any case a signed JSON Web Token is provided by the related Identity Provider.
 
 The following sections describe example flows that can be used.The following terms are used in the description:
 
@@ -484,7 +481,7 @@ _Client credentials are used as an authorization grant typically when the client
 * The application credentials are client id and client secret.
 * This flow is best suited for Machine-to-Machine (M2M) applications, such as CLIs, daemons, or backend services.
 
-The system MUST authenticate and authorize the application instead of a user.
+The system authenticates and authorizes the application instead of a user.
 
 .Authentication Flow OAuth 2.0
 [[image-auth-flow-oauth]]
@@ -588,7 +585,7 @@ According to the Dataspace Protocol (DSP) xref:bibliography.adoc#bib7[[7\]], a D
 The specification goes on to define interactions between a Data Provider and Data Consumer to expose metadata, agree on conditions for exchange and execute the transfer of Datasets.
 Asset Administration Shell resources can be such Datasets.
 
-A Dataspace MAY decide for a subset of all AAS Service Specifications of AAS Part 2, e.g. using both AssetAdministrationShellRegistryServiceSpecification and SubmodelRepositoryServiceSpecification together with AssetAdministrationShellDescriptors and included SubmodelDescriptors. Specific Dataspaces define conventions on the standardized exposure of these resources for Data Consumers to discover and retrieve.
+A Dataspace decides which AAS Service Specifications of AAS Part 2 it wants to use, e.g. using both AssetAdministrationShellRegistryServiceSpecification and SubmodelRepositoryServiceSpecification together with AssetAdministrationShellDescriptors and included SubmodelDescriptors. Specific Dataspaces define conventions on the standardized exposure of these resources for Data Consumers to discover and retrieve.
 
 .Dataspace Protocol negotiation with integrated SSI-based authentication flow for credential presentation
 [[image-auth-flow-dataspace]]
@@ -597,8 +594,8 @@ A Dataspace MAY decide for a subset of all AAS Service Specifications of AAS Par
 include::partial$diagrams/auth-flow-dataspace.puml[]
 ....
 
-A Provider will define access conditions encoded as ODRL-Policies that a potential Consumer MUST comply with.
-To authorize against these Policies, a Consumer MAY be REQUIRED to provide access to long-living claims signed by a commonly trusted party (Identity Provider, step 1).
+A Provider will define access conditions encoded as ODRL-Policies that he expects a potential Consumer to comply with.
+To authorize against these Policies, a Consumer provides access to long-living claims signed by a commonly trusted party (Identity Provider, step 1).
 These claims will usually follow the Verifiable Credential Data Model embedded in a jwt (see <<image-verifiable-credential>>):
 
 .Example Verifiable Credential for authentication and authorization against Dataspace Protocol endpoints
@@ -616,39 +613,10 @@ The Tokens’ format is usually irrelevant for interoperability as it is issued 
 Only scenarios where the Policy Decision Point and Policy Enforcement Point are implemented in separate runtimes, possibly from different vendors, require standardization of such tokens.
 Access concludes by presenting said short-lived token to the server hosting the AAS-resource (step 7).
 
-To strike a balance between granularity and public meta-data exposure, AAS resources MAY be exposed in a granular manner masking implicit information like the number of Submodels or AAS-Descriptors.
+To strike a balance between granularity and public meta-data exposure, AAS resources are exposed in a granular manner masking implicit information like the number of Submodels or AAS-Descriptors.
 The AAS-Registry API completes the Data Consumer’s discovery-sequence by linking the Submodels from distributed data sources while at the same time protecting the AAS-Descriptor objects from the public.
 
 The AAS data server and the AAS registry will evaluate and check the claims in the token by the Access Rules as specified later in this specification.
-
-== Access token
-
-An AAS Data Server trusts one or several Identity Providers.
-An Identity Provider MAY also give the possibility to federate identities to/from other Identity Providers.
-
-Trust means, that for such Identity Provider(s) an AAS Data Server can verify the public key of the Identity Provider.
-Such public key MAY be available directly as a key, by a public certificate or by a verifiable credential.
-
-AAS Security uses signed JWT (JSON Web Token) bearer tokens as Access Tokens, as they are defined in RFC 7519.
-
-The JWT is digitally signed according to RFC 7519 with the private key of the Identity Provider.
-The public key needs to be accessible by the AAS server, such that the JWT can be verified.
-The key length SHOULD follow best practices.
-Other properties like the lifetime of the token or Proof-of-Possession (RFC 7800) properties can be determined based on the use case.
-
-AAS Security only requires the standard claims of the RFC 9068 Chapter 2.2 Data Structure for the JWT, i.e “iss” (Issuer), “exp” (Expiration time), “aud” (Audience), “sub” (Subject), “client_id” (Client identifier), “iat” (Issued at), “jti” (JWT ID).
-
-Dataspaces SHOULD define their specific requirements on “iss”, “sub” and “aud”.
-
-All claims in an Access Token can be used in ABAC access rules as attributes and as described in the Access Rule Model below.
-
-Access rules can also be defined for anonymous access, i.e. no Access Token exists. +
-This is especially important for the Digital Product Passport to be able to scan the QRCODE according to IEC 61406 with a normal mobile phone camera.
-
-Further definitions can be made by dataspaces.
-A specific dataspace MAY define the technology how to get an access token and MAY also define the attributes which can be used in the ABAC access rules.
-
-This both assures interoperability and makes it possible to integrate new dataspaces in the future.
 
 == IEC 63278
 

--- a/documentation/IDTA-01004/modules/ROOT/pages/requirements.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/requirements.adoc
@@ -42,7 +42,7 @@ Identification and authentication of AAS user applications and AAS interface pro
 * Before granting access to protected data represented by the AAS or restricted services, the AAS interface SHALL ensure the identification and authentication of the AAS user application. Authentication of the AAS user application SHALL include the authentication of ABAC attributes provided by the AAS user application. The content of the ABAC attributes can affect the behaviour of the AAS interface. All ABAC attributes provided by the AAS user application can be used for authorization decisions.
 * If requested by the AAS user application the AAS interface SHOULD be able to prove its identity towards the AAS user application.
 
-Identification and authentication of the AAS user application and the AAS interface can be achieved by different means, depending on the underlying communication technology and REQUIRED security level (<<_public_key_infrastructure>>).
+Identification and authentication of the AAS user application and the AAS interface can be achieved by different means, depending on the underlying communication technology and required security level (<<_public_key_infrastructure>>).
 
 ====
 Note: In case of TCP/IP based communication (mutual) TLS can be used to provide secure identification between the communication partners.
@@ -280,21 +280,22 @@ This requirement is relevant for two aspects of the AAS security model:
 Note: In case of TCP/IP based communication TLS can be used to ensure confidentiality protection for data in transit.
 ====
 
-Confidentiality for data at rest can be implemented by different means, depending on the REQUIRED security level. 
+Confidentiality for data at rest can be implemented by different means, depending on the required security level. 
 
 Measures include:
 
 * Implementation of access control (<<_authorization_enforcement>>).
 * Use of protected storage systems and data bases relying on cryptographic encryption mechanisms (symmetric and asymmetric) on the actual data.
-* Providing information by-reference instead of by-value. The responsibility to protect the information is delegated to the referenced data source. Delegation is an option to be considered in case AAS is not able to meet the REQUIRED protection level.
+* Providing information by-reference instead of by-value. The responsibility to protect the information is delegated to the referenced data source. Delegation is an option to be considered in case AAS is not able to meet the required protection level.
 
 ====
 Note: Derived from IEC 62443-3-3 SR 4.1, IEC 62443-4-2 CR 4.1
 ====
 
+[[use-of-cryptography]]
 ==== Use of cryptography
 
-If no details are mentioned on REQUIRED cryptographic algorithms or strength used to implement AAS security functionality, the latest version of [ENISA Report] or [NIST SP 800-78-5] SHOULD be used as a reference.
+If no details are mentioned on required cryptographic algorithms or strength used to implement AAS security functionality, the latest version of [ENISA Report] or [NIST SP 800-78-5] SHOULD be used as a reference.
 
 ====
 Note: Derived from IEC 62443-3-3 SR 4.3, IEC 62443-4-2 CR 4.3
@@ -304,7 +305,7 @@ Note: Derived from IEC 62443-3-3 SR 4.3, IEC 62443-4-2 CR 4.3
 
 ==== Application partitioning
 
-The definition of AAS structures SHOULD consider separation of content based on associated risk, relevant security objectives, or other criteria, operational function, REQUIRED access (for example, least privilege principles) or responsible organization.
+The definition of AAS structures SHOULD consider separation of content based on associated risk, relevant security objectives, or other criteria, operational function, required access (for example, least privilege principles) or responsible organization.
 
 Restricted data flow is an important concept of IEC 62443.
 

--- a/documentation/IDTA-01004/modules/ROOT/pages/security-objectives.adoc
+++ b/documentation/IDTA-01004/modules/ROOT/pages/security-objectives.adoc
@@ -20,7 +20,7 @@ Information security has traditionally focused on achieving three objectives, co
 *Integrity of AAS interface behaviour:* AAS SHALL ensure the logical correctness and reliability of data represented by the AAS as well as structure and occurrence of the data represented by the AAS. AAS SHALL ensure that data is provided in a consistent and reproducible way. The AAS interface SHALL ensure the authenticity, reliability, and security of API interactions, preventing unauthorized access and abuse. Execution of operations and access to data SHALL behave in a predictable manner.
 
 ====
-Note: The amount of data represented by the AAS being visible and the AAS services being available are subject to access control (xref:requirements.adoc#_authorization_enforcement[Authorization enforcement], xref:access-rule-model.adoc#_access_rule_model_normative[Access Rule Model]). That means, the user experience depends on the privilege level of the AAS user application user. For example, it is possible that specific Submodels are only visible for privileged repair personnel. Refer to IEC 63278-4 4.7.5 for additional explanation. Using ABAC, the amount of information can also depend on additional criteria, like the operation status of a manufacturing system.
+Note: The amount of data represented by the AAS being visible and the AAS services being available are subject to access control (xref:requirements.adoc#_authorization_enforcement[Authorization enforcement], xref:access-rule-model.adoc#_access_rule_model_normative[Access Rule Model]). That means, the user experience depends on the privilege level of the AAS user application user. For example, it is possible that specific Submodels are only visible for privileged repair personnel. Using ABAC, the amount of information can also depend on additional criteria, like the operation status of a manufacturing system.
 ====
 
 *Integrity and accountability of data:* The AAS user application user expects the data of the AAS provided via the AAS interface to be correct and reliable. Protection of integrity and accountability of AAS data SHALL consider the following:
@@ -44,10 +44,6 @@ Note: The amount of data represented by the AAS being visible and the AAS servic
 as well as the
 
 * structure and meta-data represented by the AAS (topology described Submodels, SubmodelElements, SubmodelElementCollections, ...).
-
-====
-Note: Refer to IEC 63278-4 4.7 for additional explanation.
-====
 
 == Availability
 


### PR DESCRIPTION
* Eliminated most provisions from introduction.adoc
    - Moved essential provissions to =General section of access-rule-model.adoc
    - Removed/rephrased remaining SHALL, SHOULD, MUST.
    - Rephrased most MAY provisions as statements (introduciton.adoc is concrete examples, i.e., it is OK to assume that they work in a specific way)
    - CAN provisions have not been revised (these do not hurt); However, many of these do still not address the actual subject of standardization.
    - Section =Access Tokens relocated to access-rule-model.adoc as the provisions for Acccess Tokens are essential for the security model to work.
* Aligned section =Access Token with respective clause from IEC (some @todos remain as comments for the next edition)
* Synced information provided in section =Attribute base access control (ABAC) with the respective clause from IEC